### PR TITLE
Remove extra vendor field from cartridge name

### DIFF
--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,4 +1,4 @@
-Name: jboss-unified-push
+Name: unified-push
 Cartridge-Short-Name: JBOSS_UNIFIED_PUSH
 Display-Name: JBoss Unified Push Server 1.0.0.Beta1
 Description: "Provides the JBoss Unified Push Server, a server that allows sending push notifications to different mobile platforms. Runs on JBoss EAP Server 6."


### PR DESCRIPTION
This PR changes output of `rhc cartridge-list` as follows:

``` diff
- jboss-jboss-unified-push-1.0.1 (!) JBoss Unified Push Server 1.0.0.Beta1   web
+ jboss-unified-push-1.0.1 (!) JBoss Unified Push Server 1.0.1.Beta1   web
```
