### PR TITLE
[master] Hide minor/bugfix versions from rhc tools

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,12 +2,7 @@
 
 source $OPENSHIFT_UNIFIED_PUSH_DIR/bin/util
 
-case "$1" in
-  -v|--version)
-    version="$2"
-esac
-
-echo "$version" > "$OPENSHIFT_UNIFIED_PUSH_DIR/env/OPENSHIFT_UNIFIED_PUSH_VERSION"
+version="$OPENSHIFT_UNIFIED_PUSH_VERSION"
 
 ln -s ${OPENSHIFT_UNIFIED_PUSH_DIR}/standalone/log ${OPENSHIFT_UNIFIED_PUSH_DIR}/logs
 

--- a/bin/setup
+++ b/bin/setup
@@ -5,6 +5,18 @@ case "$1" in
     version="$2"
 esac
 
+case $version in
+1)
+  # Add minor and bugfix version
+  version=1.0.2
+  ;;
+*)
+  echo "Unsupported unified-push version $version" >&2
+  exit 1
+esac
+
+echo "$version" > "$OPENSHIFT_UNIFIED_PUSH_DIR/env/OPENSHIFT_UNIFIED_PUSH_VERSION"
+
 # Create additional directories required by JBOSSAS
 mkdir -p ${OPENSHIFT_HOMEDIR}/.m2
 mkdir -p ${OPENSHIFT_UNIFIED_PUSH_DIR}/{standalone/tmp,standalone/deployments,standalone/configuration,standalone/log,standalone/data}

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,12 +1,12 @@
 Name: unified-push
 Cartridge-Short-Name: UNIFIED_PUSH
-Display-Name: JBoss Unified Push Server 1.0.0.Beta1
+Display-Name: JBoss Unified Push Server 1.0.2.Beta1
 Description: "Provides the JBoss Unified Push Server, a server that allows sending push notifications to different mobile platforms. Runs on JBoss EAP Server 6."
-Version: 1.0.2
+Version: 1
 License: "ASL 2.0"
 License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
 Vendor: Red Hat
-Cartridge-Version: 1.0.0
+Cartridge-Version: 1.0.2.1
 Cartridge-Vendor: jboss
 Source-Url: https://github.com/jboss-mobile/jboss-unified-push-openshift-cartridge/archive/master.zip
 Categories:


### PR DESCRIPTION
- Makes INT/STG/PROD release updates easier
- rhc tools will show only the latest version for a particular
  major version of the Unified Push Server
